### PR TITLE
feat: Update Dockerfile to support non-root users

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,13 @@ RUN apt-get -qq update && \
     "jax[cuda]==0.3.25" && \
     mkdir -p -v /docker && \
     curl -sL https://raw.githubusercontent.com/matthewfeickert/nvidia-gpu-ml-library-test/main/jax_detect_GPU.py \
-        -o /docker/jax_detect_GPU.py
+        -o /docker/jax_detect_GPU.py && \
+    mkdir -p -v /.cache && \
+    chmod -R 777 /usr/local/venv && \
+    chmod -R 777 /.cache
+
+# Creation of a /.cache dir and chmod to universal write is to allow for pip installs
+# into the virtual environment by non-root users
 
 # CONTROL FOR MANUAL BUILD
 # # N.B. variable CUDA_VERSION already exists in the image

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,3 +62,5 @@ RUN apt-get -qq update && \
 #     --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html \
 #     "jax==${JAX_VERSION}" \
 #     "jaxlib==${JAXLIB_VERSION}+${CUDA_VERSION_MAJOR}.${CUDNN_VERSION}"
+
+WORKDIR /work

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,8 +30,10 @@ RUN apt-get -qq update && \
     curl -sL https://raw.githubusercontent.com/matthewfeickert/nvidia-gpu-ml-library-test/main/jax_detect_GPU.py \
         -o /docker/jax_detect_GPU.py && \
     mkdir -p -v /.cache && \
+    mkdir -p -v /work && \
     chmod -R 777 /usr/local/venv && \
-    chmod -R 777 /.cache
+    chmod -R 777 /.cache && \
+    chmod -R 777 /work
 
 # Creation of a /.cache dir and chmod to universal write is to allow for pip installs
 # into the virtual environment by non-root users

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,11 +29,19 @@ RUN apt-get -qq update && \
     mkdir -p -v /docker && \
     curl -sL https://raw.githubusercontent.com/matthewfeickert/nvidia-gpu-ml-library-test/main/jax_detect_GPU.py \
         -o /docker/jax_detect_GPU.py && \
-    mkdir -p -v /.cache && \
-    mkdir -p -v /work && \
-    chmod -R 777 /usr/local/venv && \
-    chmod -R 777 /.cache && \
-    chmod -R 777 /work
+    mkdir -p -v \
+        /.local \
+        /.config \
+        /.cache \
+        /.jupyter \
+        /work && \
+    chmod --recursive 777 \
+        /usr/local/venv \
+        /.local \
+        /.config \
+        /.cache \
+        /.jupyter \
+        /work
 
 # Creation of a /.cache dir and chmod to universal write is to allow for pip installs
 # into the virtual environment by non-root users

--- a/htcondor_templates/chtc_hello_gpu/interactive_submit.sh
+++ b/htcondor_templates/chtc_hello_gpu/interactive_submit.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+condor_submit -interactive chtc_hello_gpu.sub

--- a/htcondor_templates/chtc_hello_gpu/interactive_submit.sh
+++ b/htcondor_templates/chtc_hello_gpu/interactive_submit.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-condor_submit -interactive chtc_hello_gpu.sub

--- a/noxfile.py
+++ b/noxfile.py
@@ -31,7 +31,6 @@ def build(session):
         run_command = [
             "docker",
             "build",
-            ".",
             "--file",
             "docker/Dockerfile",
             "--build-arg",
@@ -45,6 +44,7 @@ def build(session):
         ]
         if base_image == default_image:
             run_command += ["--tag", f"pyhf/cuda:latest-{pyhf_backend}"]
+        run_command += "."
         session.run(*run_command, external=True)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -15,30 +15,37 @@ def build(session):
     """
     Build image
     """
-    base_image = "nvidia/cuda:11.6.0-cudnn8-devel-ubuntu20.04"
+
+    default_image = "nvidia/cuda:11.6.0-cudnn8-devel-ubuntu20.04"
+    target_images = [
+        default_image,
+        "nvidia/cuda:11.2.2-devel-ubuntu20.04",
+        "nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04",
+    ]
     pyhf_version = "0.7.0"
     pyhf_backend = "jax"
-    cuda_version = base_image.split(":")[-1].split("-devel")[0]
+    for base_image in target_images:
+        cuda_version = base_image.split(":")[-1].split("-devel")[0]
 
-    session.run("docker", "pull", base_image, external=True)
-    session.run(
-        "docker",
-        "build",
-        "--file",
-        "docker/Dockerfile",
-        "--build-arg",
-        f"BASE_IMAGE={base_image}",
-        "--build-arg",
-        f"PYHF_VERSION={pyhf_version}",
-        "--build-arg",
-        f"PYHF_BACKEND={pyhf_backend}",
-        "--tag",
-        f"pyhf/cuda:{pyhf_version}-{pyhf_backend}-cuda-{cuda_version}",
-        "--tag",
-        f"pyhf/cuda:latest-{pyhf_backend}",
-        ".",
-        external=True,
-    )
+        session.run("docker", "pull", base_image, external=True)
+        run_command = [
+            "docker",
+            "build",
+            ".",
+            "--file",
+            "docker/Dockerfile",
+            "--build-arg",
+            f"BASE_IMAGE={base_image}",
+            "--build-arg",
+            f"PYHF_VERSION={pyhf_version}",
+            "--build-arg",
+            f"PYHF_BACKEND={pyhf_backend}",
+            "--tag",
+            f"pyhf/cuda:{pyhf_version}-{pyhf_backend}-cuda-{cuda_version}",
+        ]
+        if base_image == default_image:
+            run_command += ["--tag", f"pyhf/cuda:latest-{pyhf_backend}"]
+        session.run(*run_command, external=True)
 
 
 @nox.session()


### PR DESCRIPTION
```
* Create top level directories /.local /.config /.cache /.jupyter /work
  that are writeable by all users and make /usr/local/venv writable to
  allow for interactive use by non-root users.
* Set WORKDIR to be all user writable /work directory.
* Make 'build' nox session build the image for three common nvidia/cuda base images:
  nvidia/cuda:11.2.2-devel-ubuntu20.04, nvidia/cuda:11.6.0-cudnn8-devel-ubuntu20.04,
  nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04. Set the 11.6.0-cudnn8-devel-ubuntu20.04
  base image to be the default that 'latest-jax' is built against. 
```