### PR TITLE
feat: Add docker_pull_policy option

### DIFF
--- a/htcondor_templates/chtc_hello_gpu/chtc_hello_gpu.sub
+++ b/htcondor_templates/chtc_hello_gpu/chtc_hello_gpu.sub
@@ -3,6 +3,8 @@
 
 # Must set the universe to Docker
 universe = docker
+# To avoid Docker Hub rate limits set as "missing" (default value) unless "always" needed for updated tag
+docker_pull_policy = missing
 docker_image = pyhf/cuda:0.7.0-jax-cuda-11.6.0-cudnn8
 
 # set the log, error and output files


### PR DESCRIPTION
* Add 'docker_pull_policy = missing' as explicit default with note on when to use new 'always' option added in HTCondor v10.2.
   - c.f. https://github.com/htcondor/htcondor/pull/1029 (thanks for adding this!)